### PR TITLE
Fixing overfunding bug

### DIFF
--- a/ICO_Template/ICO_Template.cs
+++ b/ICO_Template/ICO_Template.cs
@@ -1,4 +1,4 @@
-﻿using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework;
 using Neo.SmartContract.Framework.Services.Neo;
 using Neo.SmartContract.Framework.Services.System;
 using System;
@@ -121,8 +121,16 @@ namespace Neo.SmartContract
             // 众筹成功
             ulong token = value * swap_rate / 100000000;
             BigInteger balance = Storage.Get(Storage.CurrentContext, sender).AsBigInteger();
-            Storage.Put(Storage.CurrentContext, sender, token + balance);
             BigInteger totalSupply = Storage.Get(Storage.CurrentContext, "totalSupply").AsBigInteger();
+
+            if (totalSupply + token > total_amount)
+            {
+                //This will take us over the limit, reject
+                Refund(sender, value);
+                return false;
+            }
+
+            Storage.Put(Storage.CurrentContext, sender, token + balance);
             Storage.Put(Storage.CurrentContext, "totalSupply", token + totalSupply);
             Transferred(null, sender, token);
             return true;


### PR DESCRIPTION
Bug whereby it is possible to overfund the ICO above the total_amount fixed raise by sending a huge amount of asset as the final sender.