### PR TITLE
Bugfix in empty array return for ICO template

### DIFF
--- a/ICO_Template/ICO_Template.cs
+++ b/ICO_Template/ICO_Template.cs
@@ -215,7 +215,7 @@ namespace Neo.SmartContract
             {
                 if (output.AssetId == neo_asset_id) return output.ScriptHash;
             }
-            return new byte[0];
+            return new byte[]{};
         }
 
         // get smart contract script hash


### PR DESCRIPTION
A typo in ICO template was preventing it to be properly compiled and having the avm generated.